### PR TITLE
Add throttling to refresh() and centralize property changes

### DIFF
--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -47,7 +47,7 @@ export const LitElement = (superclass: HTMLClass) => class extends superclass {
     static properties: properties;
     __data: data = {};
     _methodsToCall: methodsToCall = {};
-    _wait: boolean;
+    _wait: any;
     afterFirstRender?: () => void;
     shadowRoot: ShadowRoot;
     _propAttr: Map<string, string>;
@@ -240,9 +240,16 @@ export const LitElement = (superclass: HTMLClass) => class extends superclass {
      *
      */
     refresh() {
-        if (!this._wait) {
-            litRender(this.render(), this.shadowRoot)
+        if (this._wait === true) { return }
+        if (this._wait) {
+            // Reset the throttle
+            clearTimeout( this._wait );
         }
+
+        this._wait = setTimeout( () => {
+            delete this._wait;
+            litRender(this.render(), this.shadowRoot)
+        }, 5)
     }
 
     /**


### PR DESCRIPTION
In refresh(), add throttling to consolidate quick calls resulting from multiple property changes to reduce the number of actual renders:
- when a refresh is triggered, use `this._wait` to hold a throttle timer;
- if additional refresh requests are made, clear and reset the timer;

Only update `this.__data` in `_propertiesChanged()` and only if the new value differs from the old.

Update the property observer API to include both the new value and the old to more closely match the attribute change callbacks.

If the property observer returns `false`, skip the call to `refresh()` to allow property changes that don't alter rendering but *may* change the presentation (via CSS attribute rules).

