### PR TITLE
Avoid the delay of refresh() on initial connection

### DIFF
--- a/src/lit-lite.ts
+++ b/src/lit-lite.ts
@@ -96,7 +96,11 @@ export const LitLite =
                 delete this._wait;
 
                 this._firstRender = true;
-                this.refresh();
+
+                /* Perform the first render after connection immediately
+                 * without the delay of refresh()
+                 */
+                renderFunction(this.render(), this.shadowRoot)
             }
 
             /**


### PR DESCRIPTION
Update connectedCallback() to perform an immediate first render avoiding the delay of refresh().