### PR TITLE
Using CustomEvent instead of Event

### DIFF
--- a/src/lit-lite.ts
+++ b/src/lit-lite.ts
@@ -130,7 +130,7 @@ export const LitLite =
                             this._propertiesChanged(prop, resolved);
                         }
                         if(info.notify) {
-                            (<HTMLElement>this).dispatchEvent(new Event(`${attr}-changed`, <LitEventInit>{
+                            (<HTMLElement>this).dispatchEvent(new CustomEvent(`${attr}-changed`, <LitEventInit>{
                                 bubbles: true,
                                 composed: true,
                                 detail: resolved


### PR DESCRIPTION
The `event.detail` information doesn't seem to get populated when using the standard `Event`. Works fine when dispatching a `CustomEvent` instead.